### PR TITLE
* Issue:RabbitMQ.Client.Exceptions.AlreadyClosedException: Already cl…

### DIFF
--- a/src/CrossQueue.Hub/Services/Implementations/RabbitMQPubSub.cs
+++ b/src/CrossQueue.Hub/Services/Implementations/RabbitMQPubSub.cs
@@ -15,7 +15,7 @@ namespace CrossQueue.Hub.Services.Implementations
     {
         private readonly CrossQueueOptions _options;
         private readonly IRabbitMQConnection _connection;
-        private IModel _channel;
+        private IModel _publisherChannel;
         private readonly AsyncRetryPolicy _publishRetryPolicy;
         private readonly AsyncRetryPolicy _consumerRetryPolicy;
         private readonly ILogger<RabbitMQPubSub> _logger;
@@ -27,8 +27,8 @@ namespace CrossQueue.Hub.Services.Implementations
             _logger = logger;
             _options = options.Value;
 
-            _channel = _connection.CreateChannel();
-            _channel.ExchangeDeclare(_options.RabbitMQ.DefaultExchange,
+            _publisherChannel = _connection.CreateChannel();
+            _publisherChannel.ExchangeDeclare(_options.RabbitMQ.DefaultExchange,
                                      _options.RabbitMQ.DefaultExchangeType,
                                      durable: _options.RabbitMQ.Durable);
 
@@ -61,13 +61,15 @@ namespace CrossQueue.Hub.Services.Implementations
             await _publishRetryPolicy.ExecuteAsync(async () =>
             {
                 var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message));
-                var props = _channel.CreateBasicProperties();
+                var props = _publisherChannel.CreateBasicProperties();
                 props.Persistent = true;
 
-                _channel.BasicPublish(exchange: targetExchange,
-                                      routingKey: routingKey,
-                                      basicProperties: props,
-                                      body: body);
+                _publisherChannel.BasicPublish(
+                    exchange: targetExchange,
+                    routingKey: routingKey,
+                    basicProperties: props,
+                    body: body
+                );
 
                 await Task.CompletedTask;
             });
@@ -76,42 +78,73 @@ namespace CrossQueue.Hub.Services.Implementations
         public void Subscribe<T>(string queue, Func<T, Task> handler, string? exchange = null, string routingKey = "")
         {
             var targetExchange = exchange ?? _options.RabbitMQ.DefaultExchange;
-            _channel = _connection.CreateChannel();
-            _channel.ExchangeDeclare(targetExchange,
-                                     _options.RabbitMQ.DefaultExchangeType,
-                                     durable: _options.RabbitMQ.Durable);
+
+            // ✅ Create a dedicated channel for this subscription
+            var channel = _connection.CreateChannel();
+
+            channel.ExchangeDeclare(
+                targetExchange,
+                _options.RabbitMQ.DefaultExchangeType,
+                durable: _options.RabbitMQ.Durable
+            );
 
             var args = new Dictionary<string, object>
             {
                 { "x-dead-letter-exchange", _options.RabbitMQ.DeadLetterExchange }
             };
 
-            _channel.QueueDeclare(queue, durable: _options.RabbitMQ.Durable, exclusive: false, autoDelete: false, arguments: args);
-            _channel.QueueBind(queue, targetExchange, routingKey);
+            channel.QueueDeclare(
+                queue,
+                durable: _options.RabbitMQ.Durable,
+                exclusive: false,
+                autoDelete: false,
+                arguments: args
+            );
 
-            var consumer = new AsyncEventingBasicConsumer(_channel);
+            channel.QueueBind(queue, targetExchange, routingKey);
+
+            var consumer = new AsyncEventingBasicConsumer(channel);
 
             consumer.Received += async (_, ea) =>
             {
                 try
                 {
-                    var message = JsonSerializer.Deserialize<T>(ea.Body.ToArray())!;
-                    await _consumerRetryPolicy.ExecuteAsync(async () => await handler(message));
-                    _channel.BasicAck(ea.DeliveryTag, false);
+                    var message = JsonSerializer.Deserialize<T>(ea.Body.ToArray(), new JsonSerializerOptions
+                    {
+                        PropertyNameCaseInsensitive = true
+                    });
+
+                    if (message is null)
+                    {
+                        _logger.LogWarning("Null/invalid message received on {Queue}", queue);
+                        channel.BasicReject(ea.DeliveryTag, requeue: false); // send to DLX
+                        return;
+                    }
+
+                    await _consumerRetryPolicy.ExecuteAsync(() => handler(message));
+
+                    channel.BasicAck(ea.DeliveryTag, multiple: false);
                 }
                 catch (JsonException ex)
                 {
-                    _logger.LogError($"A JsonException occurred: {ex.Message}");
-                    _channel.BasicNack(ea.DeliveryTag, false, requeue: false);
+                    _logger.LogError(ex, "Invalid JSON for message from {Queue}", queue);
+                    channel.BasicReject(ea.DeliveryTag, requeue: false);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error handling message from {Queue}", queue);
-                    _channel.BasicNack(ea.DeliveryTag, false, requeue: false);
+                    channel.BasicReject(ea.DeliveryTag, requeue: false);
                 }
             };
 
-            _channel.BasicConsume(queue, autoAck: false, consumer);
+            channel.BasicConsume(queue, autoAck: false, consumer);
+
+            channel.ModelShutdown += (_, args) =>
+            {
+                _logger.LogWarning("Channel for {Queue} closed: {ReplyCode} - {ReplyText}",
+                    queue, args.ReplyCode, args.ReplyText);
+            };
+
             _logger.LogInformation("Subscribed to {Queue} with routingKey {RoutingKey}", queue, routingKey);
         }
     }


### PR DESCRIPTION
…osed: The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=406, text='PRECONDITION_FAILED - unknown delivery tag 1'

* Fix: Used one chnnel per consumer